### PR TITLE
fix hmetis parsing

### DIFF
--- a/src/Parsing.cpp
+++ b/src/Parsing.cpp
@@ -41,17 +41,24 @@ auto generate_hmetis_graph_parser(part::Hypergraph& graph)
     namespace x3 = boost::spirit::x3;
     namespace fusion = boost::fusion;
 
-    auto parsing_function = [&graph](auto&& ctx) {
+    uint64_t edge_id = 0;
+    auto parsing_function = [&graph,&edge_id](auto&& ctx) {
         std::vector<uint64_t> vtx_list;
-        uint64_t edge;
-        auto tup = std::tie(edge, vtx_list);
-
+        uint64_t first_vertex_of_edge;
+        auto tup = std::tie(first_vertex_of_edge, vtx_list);
         fusion::move(std::move(x3::_attr(std::move(ctx))), tup);
 
-        graph.addNodeList(edge, vtx_list);
+        vtx_list.push_back(first_vertex_of_edge);
+
+        // now vtx_list contains all pins of edge edge_id
+        graph.addNodeList(edge_id, vtx_list);
+
+
+        ++edge_id;
     };
 
-    auto line = x3::uint64 > +x3::uint64 > x3::eol;
+    // account for single-node hyperedges
+    auto line = x3::uint64 > *x3::uint64 > x3::eol;
     auto empty_edge = x3::uint64 > x3::eol;
 
     return x3::uint64


### PR DESCRIPTION
hMetis files are structured as
follows: The first line contains 2 integers: the number of hyperedges
and the number of vertices. Every following line then corresponds
to a _hyperedge_, i.e., each line lists the pins of a hyperedge
(see: http://glaros.dtc.umn.edu/gkhome/fetch/sw/hmetis/manual.pdf
Section 3.4).

Parsing of hMetis files was incorrect:
1.) The code treated the first pin as the 'ID' of the hyperedge.
2.) The parser crashed when the file contained single-node hyperedges.

The crash can easily be reproduces by parsing the following
hypergraph:

2 3
1 2 3
1

The fact that parsing was done incorrectly can easily be reproduces by parsing the following
hypergraph:

2 3
1 2 3
1 2

Which created a hypergraph with onle a single hyperedge of ID 1.